### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,21 @@ go 1.17
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211221011931-643d94fcab96
+	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
+	github.com/fatih/color v1.13.0
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/pkg/errors v0.9.1
+	github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe
+	github.com/tj/go-update v2.2.5-0.20200519121640-62b4b798fd68+incompatible
+	github.com/twmb/murmur3 v1.1.6
+	golang.org/x/text v0.3.7
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
 	github.com/apex/log v1.9.0 // indirect
 	github.com/c4milo/unpackit v0.1.0 // indirect
-	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/dsnet/compress v0.0.1 // indirect
-	github.com/fatih/color v1.13.0
 	github.com/google/go-github v17.0.0+incompatible // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gosuri/uilive v0.0.4 // indirect
@@ -18,13 +28,6 @@ require (
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
-	github.com/pkg/errors v0.9.1
-	github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe
-	github.com/tj/go-update v2.2.5-0.20200519121640-62b4b798fd68+incompatible
-	github.com/twmb/murmur3 v1.1.6
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
-	golang.org/x/text v0.3.7
-	gopkg.in/yaml.v2 v2.4.0
 )

--- a/internal/cli/parser.go
+++ b/internal/cli/parser.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -349,10 +348,10 @@ func checkUpdateInfo() {
 	lastFile := filepath.Join(filepath.Dir(utils.GetDefaultConf()), ".fofax-last")
 	if !utils.FileExist(lastFile) {
 		_ = os.MkdirAll(filepath.Dir(lastFile), os.ModePerm)
-		err := ioutil.WriteFile(lastFile, []byte(strings.TrimSpace(Date)), os.ModePerm)
+		err := os.WriteFile(lastFile, []byte(strings.TrimSpace(Date)), os.ModePerm)
 		printer.Fatal(err)
 	}
-	lastTime, err := ioutil.ReadFile(lastFile)
+	lastTime, err := os.ReadFile(lastFile)
 	if err != nil {
 		printer.Error(err)
 		return
@@ -367,7 +366,7 @@ func checkUpdateInfo() {
 		if err != nil {
 			printer.Error(err.Error())
 		}
-		err = ioutil.WriteFile(lastFile, []byte(time.Now().Format("2006-01-02T15:04:05Z")), os.ModePerm)
+		err = os.WriteFile(lastFile, []byte(time.Now().Format("2006-01-02T15:04:05Z")), os.ModePerm)
 		printer.Fatal(err)
 	}
 

--- a/internal/fofa/fofa_api.go
+++ b/internal/fofa/fofa_api.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -137,7 +137,7 @@ func (f *FoFa) fetchByFields(fields string, queryStr string) bool {
 			return false
 		}
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			printer.Errorf(printer.HandlerLine("body read failed: " + err.Error()))
 		}

--- a/internal/fx/fxquery.go
+++ b/internal/fx/fxquery.go
@@ -3,7 +3,7 @@ package fx
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -266,7 +266,7 @@ func trimOther(s string) string {
 }
 
 func getFxLists(path string) {
-	fs, _ := ioutil.ReadDir(path)
+	fs, _ := os.ReadDir(path)
 	for _, file := range fs {
 		if file.IsDir() {
 			fmt.Println(path + file.Name())

--- a/internal/fx/plugin.go
+++ b/internal/fx/plugin.go
@@ -1,7 +1,7 @@
 package fx
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -69,7 +69,7 @@ func (base *Plugin) GenPlugin(pluginFile string) {
 	}
 	data, _ := yaml.Marshal(base)
 	printer.Infof("Will Write Plugin file: %s", pluginFile)
-	err := ioutil.WriteFile(pluginFile, data, 0644) // 写入
+	err := os.WriteFile(pluginFile, data, 0644) // 写入
 	if err != nil {
 		printer.Fatalf("%s can't  write Plugin file", pluginFile)
 	}

--- a/internal/fx/utils.go
+++ b/internal/fx/utils.go
@@ -2,7 +2,7 @@ package fx
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -40,9 +40,9 @@ func LoadPlugin(pathFile string) (*Plugin, error) {
 	}
 	defer configFile.Close()
 
-	content, err := ioutil.ReadAll(configFile)
+	content, err := io.ReadAll(configFile)
 	if err != nil {
-		printer.Errorf("readPlugin(%s) ioutil.ReadAll failed: %v", pathFile, err)
+		printer.Errorf("readPlugin(%s) io.ReadAll failed: %v", pathFile, err)
 		return nil, err
 	}
 	plugin := &Plugin{}

--- a/internal/goflags/goflags.go
+++ b/internal/goflags/goflags.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -98,7 +97,7 @@ func (flagSet *FlagSet) Parse() error {
 
 	if _, err := os.Stat(config); os.IsNotExist(err) {
 		configData := flagSet.generateDefaultConfig()
-		err = ioutil.WriteFile(config, configData, os.ModePerm)
+		err = os.WriteFile(config, configData, os.ModePerm)
 		if err != nil {
 			printer.Errorf("create config file fail %s", config)
 		}

--- a/internal/iconhash/iconhash.go
+++ b/internal/iconhash/iconhash.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"hash"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -77,7 +77,7 @@ func (c *Config) FromUrlGetContent() (string, error) {
 		return "", err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	if c.Debug {
 		fmt.Printf("===> status code: %d\n", resp.StatusCode)
@@ -104,7 +104,7 @@ func (c *Config) FromFileGetContent() (string, error) {
 		return "", err
 	}
 	defer fi.Close()
-	content, err := ioutil.ReadAll(fi)
+	content, err := io.ReadAll(fi)
 	if c.Debug {
 		printer.Debugf("====> fileContent:\n %s\n", content)
 	}


### PR DESCRIPTION
This PR introduces two small changes:

1. Run `go mod tidy`
2. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.